### PR TITLE
Execute BuildDirectors ordered by their priority

### DIFF
--- a/Build/BuildDispatcher.php
+++ b/Build/BuildDispatcher.php
@@ -13,29 +13,29 @@ use Webfactory\Bundle\NavigationBundle\Tree\Tree;
 
 class BuildDispatcher
 {
-    protected $directors = array();
-    protected $resources = array();
+    protected $directors = [];
+    protected $resources = [];
     protected $queue;
 
-    public function addDirector(BuildDirector $m, $priority = 100)
+    public function addDirector(BuildDirector $director, $priority = 100)
     {
-        // TODO: Implement priority handling
-        $this->directors[] = $m;
+        $this->directors[$priority][] = $director;
     }
 
     public function start(Tree $tree)
     {
-        $this->queue = array(new BuildContext(array()));
-        while ($c = array_shift($this->queue)) {
-            foreach ($this->directors as $m) {
-                $m->build($c, $tree, $this);
+        $directorsOrderedByPriority = $this->getDirectorsOrderedByPriority();
+        $this->queue = [new BuildContext([])];
+        while ($context = array_shift($this->queue)) {
+            foreach ($directorsOrderedByPriority as $director) {
+                $director->build($context, $tree, $this);
             }
         }
     }
 
-    public function search(BuildContext $c)
+    public function search(BuildContext $context)
     {
-        $this->queue[] = $c;
+        $this->queue[] = $context;
     }
 
     public function addResource(ResourceInterface $resource)
@@ -46,6 +46,21 @@ class BuildDispatcher
     public function getResources()
     {
         return array_unique($this->resources);
+    }
+
+    /**
+     * @return BuildDirector[]
+     */
+    private function getDirectorsOrderedByPriority()
+    {
+        krsort($this->directors, SORT_NUMERIC);
+        $buildDirectorsOrderedByPriority = [];
+
+        foreach($this->directors as $directors) {
+            $buildDirectorsOrderedByPriority = array_merge($buildDirectorsOrderedByPriority, $directors);
+        }
+
+        return $buildDirectorsOrderedByPriority;
     }
 
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## Version 3.1.0
+
+* Execute BuildDirectors ordered by their priority.
+
 ## Version 3.0.0
 
 * Config-Einstellung `refresh_tree_for_tables`/`wfd_meta_refresh` und  Service `webfactory_navigation.tree_factory.meta_query` entfernt. Um zu bestimmen, von welchen Dingen der `Tree` abhängt, ist es jetzt nicht mehr notwendig, diese Konfigurationseinstellungen zu nutzen. Erzeuge stattdessen geeignete `ResourceInterface`-Instanzen wie z. B. `\Webfactory\Bundle\WfdMetaBundle\Config\DoctrineEntityClassResource` oder `\Webfactory\Bundle\WfdMetaBundle\Config\WfdTableResource` aus dem `WebfactoryWfdMetaBundle` (ab ^3.0.0) und füge sie dem `BuildDispatcher` hinzu, während der Baum gebaut wird. Hintergrund: Das `WebfactoryWfdMetaBundle` kann jetzt solche Resourcen über den `ConfigCacheFactory`-Mechanismus auswerten und den Cache zur Laufzeit neu erstellen. Dieses Bundle hier wird damit die Abhängigkeit vom `WebfactoryWfdMeta`-Bundle los.


### PR DESCRIPTION
Previously we didn't do anything with the
priority defined on any BuildDirector.

The priority defaults to 100 and the higher its
value the sooner a BuildDirector is executed.