### PR TITLE
Erlaube probehalber Symfony 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,17 +8,20 @@
     },
 
     "require": {
-        "ocramius/proxy-manager": "^1.0|^2.2",
-        "symfony/config": "^2.8|^3.4",
-        "symfony/console": "^2.8|^3.4",
-        "symfony/dependency-injection": "^2.8|^3.4",
-        "symfony/event-dispatcher": "^2.8|^3.4",
-        "symfony/framework-bundle": "^2.8|^3.4",
-        "symfony/http-foundation": "^2.8|^3.4",
-        "symfony/http-kernel": "^2.8|^3.4",
-        "symfony/proxy-manager-bridge": "^2.0|^3.0",
-        "symfony/stopwatch": "^2.8|^3.4",
+        "symfony/config": "^2.8|^3.4|^4.0",
+        "symfony/console": "^2.8|^3.4|^4.0",
+        "symfony/dependency-injection": "^2.8|^3.4|^4.0",
+        "symfony/event-dispatcher": "^2.8|^3.4|^4.0",
+        "symfony/framework-bundle": "^2.8|^3.4|^4.0",
+        "symfony/http-foundation": "^2.8|^3.4|^4.0",
+        "symfony/http-kernel": "^2.8|^3.4|^4.0",
+        "symfony/proxy-manager-bridge": "^2.8|^3.4|^4.0",
         "twig/twig": "^1.34|^2.0"
+    },
+    
+    "suggest": {
+        "symfony/stopwatch": "um zu messen, wie lange der Aufbau des NavigationTree dauert",
+        "ocramius/proxy-manager": "damit der NavigationTree wirklich lazy erzeugt wird"
     },
 
     "config": {


### PR DESCRIPTION
Kann in Projekten als `dev-erlaube-sf4` installiert werden.