### PR TITLE
Use "newer" template path syntax

### DIFF
--- a/Controller/NavigationController.php
+++ b/Controller/NavigationController.php
@@ -38,7 +38,7 @@ class NavigationController extends AbstractController
         $root,
         $maxLevels = 1,
         $expandedLevels = 1,
-        $template = 'WebfactoryNavigationBundle:Navigation:navigation.html.twig'
+        $template = '@WebfactoryNavigation/Navigation/navigation.html.twig'
     ) {
         if (\is_array($root)) {
             $node = $this->getTree()->find($root);
@@ -81,7 +81,7 @@ class NavigationController extends AbstractController
      *
      * @return Response
      */
-    public function ancestryAction($startLevel, $maxLevels = 1, $expandedLevels = 1, $template = 'WebfactoryNavigationBundle:Navigation:navigation.html.twig')
+    public function ancestryAction($startLevel, $maxLevels = 1, $expandedLevels = 1, $template = '@WebfactoryNavigation/Navigation/navigation.html.twig')
     {
         if ($node = $this->getTree()->getActivePath()) {
             $path = $node->getPath();
@@ -101,7 +101,7 @@ class NavigationController extends AbstractController
      *
      * @return Response
      */
-    public function breadcrumbsAction($template = 'WebfactoryNavigationBundle:Navigation:breadcrumbs.html.twig')
+    public function breadcrumbsAction($template = '@WebfactoryNavigation/Navigation/breadcrumbs.html.twig')
     {
         if ($node = $this->getTree()->getActivePath()) {
             return $this->render($template, [

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="webfactory_navigation.default_theme.file">WebfactoryNavigationBundle:Navigation:baseNavigationTheme.html.twig</parameter>
+        <parameter key="webfactory_navigation.default_theme.file">@WebfactoryNavigation/Navigation/baseNavigationTheme.html.twig</parameter>
     </parameters>
 
     <services>

--- a/Resources/views/Navigation/navigation.html.twig
+++ b/Resources/views/Navigation/navigation.html.twig
@@ -1,6 +1,6 @@
 {% if root is defined %}
 
-    {% navigation_theme root "WebfactoryNavigationBundle:Navigation:baseNavigationTheme.html.twig" %}
+    {% navigation_theme root "@WebfactoryNavigation/Navigation/baseNavigationTheme.html.twig" %}
     {{ navigation(root, maxLevels, expandedLevels) }}
 
 {% endif %}


### PR DESCRIPTION
Replace very old syntax from Symfony 2.0 days (https://symfony.com/doc/2.1/book/templating.html#template-naming-and-locations) with the "newer" syntax added in Symfony 2.2 (https://symfony.com/doc/2.2/cookbook/templating/namespaced_paths.html).

To be able to remove the deprecated Templating Component, the path syntax needs to be changed.

(For example, https://backbeat.tech/blog/how-to-remove-the-templating-component-from-a-symfony-project mentions this.)
