### PR TITLE
Allow using Symfony 5.x with the 4.x branch

### DIFF
--- a/Build/TreeFactory.php
+++ b/Build/TreeFactory.php
@@ -12,10 +12,10 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Config\ConfigCacheFactoryInterface;
 use Symfony\Component\Config\ConfigCacheInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Webfactory\Bundle\NavigationBundle\Event\TreeInitializedEvent;
 use Webfactory\Bundle\NavigationBundle\Tree\Tree;
 

--- a/Command/DumpTreeCommand.php
+++ b/Command/DumpTreeCommand.php
@@ -19,7 +19,7 @@ class DumpTreeCommand extends TreeCommand
             ->addOption('short', null, InputOption::VALUE_NONE, 'Kompakte Ausgabe');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->shortOutput = $input->getOption('short');
 
@@ -28,6 +28,8 @@ class DumpTreeCommand extends TreeCommand
         foreach ($roots as $root) {
             $this->dumpNode($root, $output);
         }
+
+        return 0;
     }
 
     private function dumpNode(Node $n, OutputInterface $output, $depth = 0)

--- a/Command/LookupNodeCommand.php
+++ b/Command/LookupNodeCommand.php
@@ -16,7 +16,7 @@ class LookupNodeCommand extends TreeCommand
              ->addArgument('queryParam', InputArgument::IS_ARRAY, 'One or several key=value pairs to search in the node index');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $provisions = [];
 
@@ -35,5 +35,7 @@ class LookupNodeCommand extends TreeCommand
         } else {
             $output->writeln('No matching node found.');
         }
+
+        return 0;
     }
 }

--- a/Event/TreeInitializedEvent.php
+++ b/Event/TreeInitializedEvent.php
@@ -8,7 +8,7 @@
 
 namespace Webfactory\Bundle\NavigationBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Webfactory\Bundle\NavigationBundle\Tree\Tree;
 
 class TreeInitializedEvent extends Event

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,22 @@
 
     "require": {
         "php": "^7.2",
-        "symfony/config": "^2.8|^3.4|^4.0",
-        "symfony/console": "^2.8|^3.4|^4.0",
-        "symfony/dependency-injection": "^3.4|^4.0",
-        "symfony/event-dispatcher": "^4.3",
-        "symfony/framework-bundle": "^3.4|^4.0",
-        "symfony/http-foundation": "^2.8|^3.4|^4.0",
-        "symfony/http-kernel": "^2.8|^3.4|^4.0",
-        "symfony/proxy-manager-bridge": "^2.8|^3.4|^4.0",
+        "psr/container": "^1.0",
+        "psr/log": "^1.1",
+        "symfony/config": "^4.0|^5.0",
+        "symfony/console": "^4.0|^5.0",
+        "symfony/dependency-injection": "^4.2|^5.0",
+        "symfony/event-dispatcher": "^4.3|^5.0",
+        "symfony/event-dispatcher-contracts": "^1.0|^2.0",
+        "symfony/http-foundation": "^4.0|^5.0",
+        "symfony/http-kernel": "^4.0|^5.0",
+        "symfony/proxy-manager-bridge": "^4.0|^5.0",
+        "symfony/service-contracts": "^1.0|^2.0",
         "twig/twig": "^1.36|^2.6"
+    },
+
+    "require-dev": {
+        "symfony/stopwatch": "^5.4"
     },
 
     "suggest": {


### PR DESCRIPTION
This merges the changes from #19 into the 4.x branch of this bundle.

Technically, it will be necessary to be at Symfony ^4.4 before the release containing these changes here can be obtained. But, being at Symfony 4.4 before attempting the migration to 5.0 should be the usual upgrade path.