### PR TITLE
Declare PHP 8.0/8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
 
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|8.0.*|8.1.*",
         "ext-json": "*",
         "psr/container": "^1.0",
         "psr/log": "^1.1",

--- a/src/Tree/Node.php
+++ b/src/Tree/Node.php
@@ -252,26 +252,40 @@ class Node implements \ArrayAccess
         return $this === $ap || $this->hasDescendant($ap);
     }
 
-    public function offsetExists($offset)
+    /**
+     * @param mixed $offset
+     */
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
 
+    /**
+     * @param mixed $offset
+     *
+     * @return mixed|null
+     */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
     }
 
-    public function offsetSet($offset, $value)
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value): void
     {
-        return $this->set($offset, $value);
+        $this->set($offset, $value);
     }
 
-    public function offsetUnset($offset)
+    /**
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
-
-        return $this;
     }
 
     protected function setParent(self $p)


### PR DESCRIPTION
This declares compatibility with PHP 8.0/8.1 and fixes a deprecation notice I encountered.

Does not use real `mixed` type hints to avoid PHP 8.0 as a minimum requirement.

Closes #15.