### PR TITLE
Use ordered list for breadcrumbs to indicate hierarchical order

### DIFF
--- a/src/Resources/views/Navigation/breadcrumbs-blocks-BEM.html.twig
+++ b/src/Resources/views/Navigation/breadcrumbs-blocks-BEM.html.twig
@@ -10,7 +10,7 @@
             {% block breadcrumbs_label %}
                 <span class="{{ block('prefix_final') ~ 'breadcrumbs__label' }} {% block breadcrumbs_label_class %}{% endblock %}">{{ "webfactory_navigation.breadcrumb_label"|trans({}, 'webfactory-navigation') }}</span>
             {% endblock %}
-            <ul class="{{ block('prefix_final') ~ 'breadcrumbs__list' }} {% block breadcrumbs_list_class %}{% endblock %}">
+            <ol class="{{ block('prefix_final') ~ 'breadcrumbs__list' }} {% block breadcrumbs_list_class %}{% endblock %}">
                 {% for node in breadcrumbs %}
                     {% if node.caption|trim is not empty and ((node.breadcrumbsVisible is defined and node.breadcrumbsVisible) or node.visible) %}
                         <li class="{{ block('prefix_final') ~ 'breadcrumbs__item' }} {% block breadcrumbs_item_class %}{% endblock %}">
@@ -24,7 +24,7 @@
                         </li>
                     {% endif %}
                 {% endfor %}
-            </ul>
+            </ol>
         </nav>
     {% endif %}
 {% endblock %}

--- a/src/Resources/views/Navigation/breadcrumbs.html.twig
+++ b/src/Resources/views/Navigation/breadcrumbs.html.twig
@@ -1,7 +1,7 @@
 {% if breadcrumbs is defined and breadcrumbs|length > 1 %}
     <div class="breadcrumb-wrapper">
         <span class="breadcrumb-label">{{ "webfactory_navigation.breadcrumb_label"|trans({}, 'webfactory-navigation') }}</span>
-        <ul class="breadcrumbs">
+        <ol class="breadcrumbs">
             {% for node in breadcrumbs %}
                 {% if node.caption|trim is not empty and ((node.breadcrumbsVisible is defined and node.breadcrumbsVisible) or node.visible) %}
                     <li class="breadcrumb {% if loop.first %}breadcrumb-first{% endif %}">
@@ -13,6 +13,6 @@
                     </li>
                 {% endif %}
             {% endfor %}
-        </ul>
+        </ol>
     </div>
 {% endif %}


### PR DESCRIPTION
This follows the official breadcrumb pattern recommendation at
https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/
