### PR TITLE
Initialize template variables with fallbacks

### DIFF
--- a/src/Resources/views/Navigation/navigationBlocks.html.twig
+++ b/src/Resources/views/Navigation/navigationBlocks.html.twig
@@ -3,6 +3,9 @@
 {# maxLevels int #}
 {# expandedLevels int #}
 {% block navigation_if_visible %}
+    {% set maxLevels = maxLevels | default(1) %}
+    {% set expandedLevels = expandedLevels | default(1) %}
+    {% set level = level | default(0) %}
     {% if level < maxLevels and (level < expandedLevels or root.activePath) %}
         {% set visibleNodes = root.children | filter(node => node.visible) %}
         {% if visibleNodes is not empty %}


### PR DESCRIPTION
This eases migration when the navigation rendering was triggered by custom controllers that did not need to initialize all these variables in 3.x.