### PR TITLE
Überarbeite Anleitung zum Upgrade auf 4.0 (Case 155469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,14 @@ Changelog
 * Kompatibilität zu Twig 3
 * Mit Version 4 entfernen wir das `navigation_theme`-Eigengebräu und ersetzen es durch Standard-Twig-Mechanismen:
   * Die separaten Theme-Dateien (z.B. `main-nav-theme.html.twig` neben einer weiterhin bestehenden
-    `main-nav-layout.html.twig`) entfallen.
+    `main-nav-layout.html.twig`) können entfallen.
   * Das Styling von Menüs ist künftig/für neue Mitarbeiter leichter verständlich.
-  * Im Projekt definierte Blöcke können oftmals entfallen, die wir schon im NavigationBundle bereitstellen - und dort zentral
+  * Im Projekt redundant definierte Blöcke können entfallen, wenn wir sie schon im NavigationBundle bereitstellen - und dort zentral
     weiterentwickeln können.
 
 ### Vorschlag für Vorgehensweise
 * `composer update webfactory/navigation-bundle` auf `^4.0`
-* Alle Navigation-Aufrufe in Twig erstmal auskommentieren, damit wir sicher sind, dass die Seite lokal sonst
+* Alle Navigation-Aufrufe in Twig erstmal auskommentieren, damit wir sicher stellen können, dass die Seite lokal prinzipiell
   funktioniert und wir auftretende Fehler in der Benutzung des NavigationBundles suchen müssen. 
 * Dann pro auskommentiertem Navigation-Aufruf:
   * Aufruf wieder aktivieren und für Version 4 anpassen. Der NavigationController ist entfallen, dafür gibt es jetzt
@@ -84,8 +84,8 @@ Changelog
     {{ navigation_breadcrumbs() }}`
     ```
 
-    Parameter der alten Aufrufe kannst Du übernehmen, musst dabei nur die Syntax anpassen: etwa im ersten Beispiel wird
-    `root` ein named Parameter, dessen Wert mit `=` statt `:` wie in der Object-Notation zugewiesen wird). Details zu
+    Die Parameter der alten Aufrufe kannst Du übernehmen, dabei musst Du nur die Syntax anpassen: etwa im ersten Beispiel wird
+    `root` ein named Parameter, dessen Wert mit `=` statt `:` wie in der Object-Notation zugewiesen wird. Details zu
     den Parametern findest Du in `NavigationExtension::renderTree`, `NavigationExtension::renderAncestry` und
     `NavigationExtension::renderBreadcrumbs`.
   * Falls in einer `main-nav-layout.html.twig` ein eigenes Theme verwendet wurde, sah die Datei beispielsweise so aus:
@@ -109,21 +109,23 @@ Changelog
       `@WebfactoryNavigation/Navigation/navigation.html.twig` genutzt), findest, kannst ihn aus Deiner
       `main-nav-layout.html.twig` löschen.
     * Wenn der Block z.B. eigene CSS-Klassen setzt, willst Du ihn wieder aktivieren und für Version 4 aktualisieren.
-      Dazu musst Du die Aufrufe der entfallenen Twig-Funktionen `navigation_list`, `navigation_list_class`, `navigation_item`,
+      Dazu musst Du eventuelle Aufrufe der entfallenen Twig-Funktionen `navigation_list`, `navigation_list_class`, `navigation_item`,
       `navigation_item_class`, `navigation_text`, `navigation_text_class`, `navigation_url` und `navigation_caption` durch
       entsprechende Aufrufe der `block()`-Funktion (ohne Parameter) ersetzen:
 
       Aus `{{ navigation_caption(themeRoot, node, level) }}` wird `{{ block('navigation_caption') }}`.
-    * Falls es dabei zu einem Fehler kommt, z.B. die Variable `nodes` nicht gefunden wurde, sollte ein Blick in die neuen
-      Blöcke in `navigationBlocks.html.twig` helfen. Dann sieht man z.B. schnell, dass jetzt die `visibleNodes` verwendet
+    * Falls es dabei zu einem Fehler kommt, z.B. die Variable `nodes` nicht gefunden wurde, sollte ein Blick auf den jeweiligen
+      Block in `navigationBlocks.html.twig` helfen. Dann sieht man z.B. schnell, dass jetzt `visibleNodes` statt `nodes` verwendet
       werden sollten. 
-    * Nach jeder Block-Aktualisierung solltest Du die Seite lokal aufrufen können.
-  * Lösche die `main-nav-layout.html.twig`.
+    * Nach jeder Block-Aktualisierung solltest Du die Seite lokal ohne 500er aufrufen können.
+  * Lösche die Theme-Datei, aus der Du die Blöcke kopiert hat (im Beispiel `main-nav-theme.html.twig`).
   * Jetzt hast Du eine Navigation aktualisiert: guter Zeitpunkt zum Comitten.
 
 ### Tipps
-* Achte darauf, dass Du lokal eine Seite aufrufst, die die zu aktualisierende Navigation auch rendert. Beispielsweise
-  haben Startseiten nicht immer eine Breadcrumb-Navigation. Passende Seiten kann man i.d.R. auf der Live-Seite suchen.
+* Achte darauf, dass Du lokal eine Seite aufrufst, die die zu aktualisierende Navigation tatsächlich rendert. Beispielsweise
+  haben Startseiten nicht immer eine Breadcrumbs-Navigation. Passende Seite kann man i.d.R. auf Live suchen.
+* Eine Footer-Navigation wird möglicherweise gar nicht mehr gerendert, wenn im Content-Bereich der Seite bereits ein Fehler
+  aufgetreten ist. Auf die Schnelle kann es helfen, die fehlerhaften Inhalte im Content-Bereich auszukommentieren.
 * Wenn Dir die aktualisierten Navigationen visuell falsch vorkommen, kannst Du Dich dem Fehler möglicherweise schnell
   über ein Diff des Production- und lokalen HTMLs annähern. 
 * Mit Version 4.1 (s.o.) wurden BEM-Templates eingeführt. Du kannst via `{% extends '@WebfactoryNavigation/Navigation/navigation-BEM.html.twig' %}`


### PR DESCRIPTION
- Bisher war das mehr als Werkzeugkiste gedacht, weil wir noch nicht wussten, ob die Werkzeuge in allen Projekten ähnlich eingesetzt werden müssen. Die Updates haben sich bisher aber als recht ähnlich herausgestellt, so dass wir die Anleitung konkreter und damit unmittelbar hilfreicher fassen können.
- Nicht alle Updates haben bisher das volle Potential ausgeschöpft, sondern z.B. die Theme-Dateien erhalten. Deshalb stellen wir das jetzt als Feature heraus und schreiben expliziter, wie man die Theme-Dateien abschaffen kann.
