### PR TITLE
Seperate navigation tree cache for each host (Case 166581)

### DIFF
--- a/src/Build/TreeFactory.php
+++ b/src/Build/TreeFactory.php
@@ -20,7 +20,10 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Webfactory\Bundle\NavigationBundle\Event\TreeInitializedEvent;
 use Webfactory\Bundle\NavigationBundle\Tree\Tree;
 
-final class TreeFactory implements ServiceSubscriberInterface
+/**
+ * @final (not actually declared final to allow it being used as a lazy service)
+ */
+class TreeFactory implements ServiceSubscriberInterface
 {
     /** @var ConfigCacheFactoryInterface */
     private $configCacheFactory;
@@ -138,6 +141,6 @@ final class TreeFactory implements ServiceSubscriberInterface
             $cacheDirectory .= $mainRequest->getHttpHost().'/';
         }
 
-        return $cacheDirectory.'tree.php';
+        return $cacheDirectory . 'tree.php';
     }
 }

--- a/src/Build/TreeFactory.php
+++ b/src/Build/TreeFactory.php
@@ -138,6 +138,6 @@ final class TreeFactory implements ServiceSubscriberInterface
             $cacheDirectory .= $mainRequest->getHttpHost().'/';
         }
 
-        return $cacheDirectory . 'tree.php';
+        return $cacheDirectory.'tree.php';
     }
 }

--- a/src/Build/TreeFactory.php
+++ b/src/Build/TreeFactory.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Webfactory\Bundle\NavigationBundle\Event\TreeInitializedEvent;
 use Webfactory\Bundle\NavigationBundle\Tree\Tree;
 
-class TreeFactory implements ServiceSubscriberInterface
+final class TreeFactory implements ServiceSubscriberInterface
 {
     /** @var ConfigCacheFactoryInterface */
     private $configCacheFactory;
@@ -27,19 +27,19 @@ class TreeFactory implements ServiceSubscriberInterface
     private $cacheFile;
 
     /** @var LoggerInterface */
-    protected $logger;
+    private $logger;
 
     /** @var Tree */
-    protected $_tree;
+    private $_tree;
 
     /** @var Stopwatch */
-    protected $stopwatch;
+    private $stopwatch;
 
     /** @var EventDispatcherInterface */
-    protected $eventDispatcher;
+    private $eventDispatcher;
 
     /** @var ContainerInterface */
-    protected $container;
+    private $container;
 
     public static function getSubscribedServices(): array
     {
@@ -71,7 +71,7 @@ class TreeFactory implements ServiceSubscriberInterface
         }
     }
 
-    protected function startTiming(string $sectionName): ?StopwatchEvent
+    private function startTiming(string $sectionName): ?StopwatchEvent
     {
         if ($this->stopwatch) {
             return $this->stopwatch->start('webfactory/navigation-bundle: '.$sectionName);
@@ -80,7 +80,7 @@ class TreeFactory implements ServiceSubscriberInterface
         return null;
     }
 
-    protected function stopTiming(StopwatchEvent $watch = null): void
+    private function stopTiming(StopwatchEvent $watch = null): void
     {
         if ($watch) {
             $watch->stop();

--- a/src/Build/TreeFactory.php
+++ b/src/Build/TreeFactory.php
@@ -141,6 +141,6 @@ class TreeFactory implements ServiceSubscriberInterface
             $cacheDirectory .= $mainRequest->getHttpHost().'/';
         }
 
-        return $cacheDirectory . 'tree.php';
+        return $cacheDirectory.'tree.php';
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,7 +11,8 @@
 
         <service id="Webfactory\Bundle\NavigationBundle\Build\TreeFactory" lazy="true">
             <argument type="service" id="config_cache_factory" />
-            <argument>%kernel.cache_dir%/webfactory_navigation/tree.php</argument>
+            <argument>%kernel.cache_dir%</argument>
+            <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack"/>
             <argument type="service" id="Psr\Container\ContainerInterface"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="logger" on-invalid="null"/>


### PR DESCRIPTION
This allows us to populate navigation trees on dedicated preview servers with host names like "preview.webfactory.de" under different visibility rules.

Technically speaking, at least two issues could be considered as BC breaks:
- the changed location of the tree cache file
- the changed constructor parameters of `TreeFactory`

But I'd like to argue that for practical reasons, both of them should be consivered as internal implementation details. The `TreeFactory` class/service was never intended to be overwritten, as suggested by the private properties ranging back to 2017. => I would tag a release as a minor version.