### PR TITLE
Vermeide Deprecation (Case 193321)

### DIFF
--- a/src/DependencyInjection/WebfactoryNavigationExtension.php
+++ b/src/DependencyInjection/WebfactoryNavigationExtension.php
@@ -11,7 +11,7 @@ namespace Webfactory\Bundle\NavigationBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class WebfactoryNavigationExtension extends Extension
 {

--- a/src/DependencyInjection/WebfactoryNavigationExtension.php
+++ b/src/DependencyInjection/WebfactoryNavigationExtension.php
@@ -10,8 +10,8 @@ namespace Webfactory\Bundle\NavigationBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class WebfactoryNavigationExtension extends Extension
 {


### PR DESCRIPTION
...durch Nutzung von `Symfony\Component\DependencyInjection\Extension\Extension` an Stelle von `Symfony\Component\HttpKernel\DependencyInjection\Extension`.
